### PR TITLE
Fix so that repo cleanup does not skip the local repository

### DIFF
--- a/dsl/procedures/artifactsCleanup/steps/dynamicCleanRepoProcedure.pl
+++ b/dsl/procedures/artifactsCleanup/steps/dynamicCleanRepoProcedure.pl
@@ -20,7 +20,15 @@ my $nodeset = $xPath->find('//repository');
 
 foreach my $node ($nodeset->get_nodelist) {
   my $repoName=$node->findvalue('repositoryName');
-  my $repoServerName = $node->findvalue('url');
+  my $repoServerName;
+
+  # The resourceName for the 'default' repository will be 'local' rather than the hostname
+  if ($repoName eq "default") {
+    $repoServerName = "local";
+  } else {
+    $repoServerName = $node->findvalue('url');
+  }
+
   my $repoDisabled = $node->findvalue('repositoryDisabled');
 
   printf("AR: %s\n", $repoName);


### PR DESCRIPTION
A customer ran into this problem. When you only have one repository, local to the Flow server, the dynamicCleanRepo procedure always skips it, and logs something like this:

```
AR: default
  Associated resource 'ip-172-31-1-127.ec2.internal' does not exist. Skipping!
```

This appears to be because the default repository resource is named 'local' rather than being named by its hostname, so we get the repo, get its url, then fail when looking up its resource using that as the name. This change appears to fix this, but it's my first try working on a Flow plugin so I may be missing something obvious!